### PR TITLE
docs(eslint-config): simplify quick start example

### DIFF
--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -24,18 +24,7 @@ import { defineConfig } from "eslint/config";
 
 import { base, react, typescript } from "@tractorbeam/eslint-config";
 
-export default defineConfig([
-  base,
-  {
-    extends: [typescript],
-    languageOptions: {
-      parserOptions: {
-        tsconfigRootDir: import.meta.dirname,
-      },
-    },
-  },
-  react,
-]);
+export default defineConfig([base, typescript, react]);
 ```
 
 ## Available Configs


### PR DESCRIPTION
## Summary
- Simplified the Quick Start example to show that the typescript config can be used directly
- Removed unnecessary `extends` wrapper and `parserOptions.tsconfigRootDir` configuration
- The typescript config uses `projectService: true` which handles tsconfig discovery automatically

## Test plan
- [x] Verified typescript config source uses `projectService: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)