### PR TITLE
feat(eslint-config,typescript-config): add Cloudflare Workers configs

### DIFF
--- a/.changeset/cloudflare-workers.md
+++ b/.changeset/cloudflare-workers.md
@@ -1,0 +1,6 @@
+---
+"@tractorbeam/eslint-config": minor
+"@tractorbeam/typescript-config": minor
+---
+
+Add Cloudflare Workers configs for ESLint and TypeScript

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -29,14 +29,15 @@ export default defineConfig([base, typescript, react]);
 
 ## Available Configs
 
-| Config           | Description                              | File Patterns                   |
-| ---------------- | ---------------------------------------- | ------------------------------- |
-| `base`           | ESLint recommended rules                 | All files                       |
-| `typescript`     | TypeScript, unicorn, regexp, import-lite | `**/*.ts`, `**/*.tsx`           |
-| `react`          | React, hooks, a11y, react-compiler       | `**/*.tsx`, `**/*.jsx`          |
-| `tanstackRouter` | TanStack Router plugin                   | `**/*.tsx`, `**/*.jsx`          |
-| `node`           | Node.js globals                          | All files                       |
-| `playwright`     | Playwright testing rules                 | No default (use with `extends`) |
+| Config              | Description                              | File Patterns                   |
+| ------------------- | ---------------------------------------- | ------------------------------- |
+| `base`              | ESLint recommended rules                 | All files                       |
+| `typescript`        | TypeScript, unicorn, regexp, import-lite | `**/*.ts`, `**/*.tsx`           |
+| `react`             | React, hooks, a11y, react-compiler       | `**/*.tsx`, `**/*.jsx`          |
+| `tanstackRouter`    | TanStack Router plugin                   | `**/*.tsx`, `**/*.jsx`          |
+| `node`              | Node.js globals                          | All files                       |
+| `cloudflareWorkers` | Cloudflare Workers globals               | All files                       |
+| `playwright`        | Playwright testing rules                 | No default (use with `extends`) |
 
 ## Customization
 

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -50,6 +50,10 @@
       "types": "./dist/node.d.ts",
       "default": "./dist/node.js"
     },
+    "./cloudflare-workers": {
+      "types": "./dist/cloudflare-workers.d.ts",
+      "default": "./dist/cloudflare-workers.js"
+    },
     "./playwright": {
       "types": "./dist/playwright.d.ts",
       "default": "./dist/playwright.js"

--- a/packages/eslint-config/src/cloudflare-workers.ts
+++ b/packages/eslint-config/src/cloudflare-workers.ts
@@ -1,0 +1,17 @@
+import type { Linter } from "eslint";
+import { defineConfig } from "eslint/config";
+import globals from "globals";
+
+export const cloudflareWorkers: Linter.Config[] = defineConfig([
+  {
+    languageOptions: {
+      globals: {
+        ...globals.serviceworker,
+        ...globals.worker,
+      },
+    },
+    rules: {
+      "no-console": "off",
+    },
+  },
+]);

--- a/packages/eslint-config/src/index.ts
+++ b/packages/eslint-config/src/index.ts
@@ -3,5 +3,6 @@ export { typescript } from "./typescript.js";
 export { react } from "./react.js";
 export { tanstackRouter } from "./tanstack-router.js";
 export { node } from "./node.js";
+export { cloudflareWorkers } from "./cloudflare-workers.js";
 export { playwright } from "./playwright.js";
 export { prettier } from "./prettier.js";

--- a/packages/typescript-config/README.md
+++ b/packages/typescript-config/README.md
@@ -27,3 +27,4 @@ In your project’s `tsconfig.json`:
 - `@tractorbeam/typescript-config/next.json`
 - `@tractorbeam/typescript-config/tanstack-start.json`
 - `@tractorbeam/typescript-config/vite.json`
+- `@tractorbeam/typescript-config/cloudflare-workers.json`

--- a/packages/typescript-config/cloudflare-workers.json
+++ b/packages/typescript-config/cloudflare-workers.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ESNext"],
+    "types": ["@cloudflare/workers-types"],
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true
+  }
+}

--- a/packages/typescript-config/cloudflare-workers.json
+++ b/packages/typescript-config/cloudflare-workers.json
@@ -1,15 +1,19 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
-    "target": "ESNext",
-    "module": "ESNext",
+    "target": "es2024",
+    "lib": ["es2024"],
+    "jsx": "react-jsx",
+    "module": "es2022",
     "moduleResolution": "Bundler",
-    "lib": ["ESNext"],
-    "types": ["@cloudflare/workers-types"],
-    "isolatedModules": true,
     "resolveJsonModule": true,
-    "skipLibCheck": true,
+    "allowJs": true,
+    "checkJs": false,
+    "noEmit": true,
+    "isolatedModules": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
     "strict": true,
-    "noEmit": true
+    "skipLibCheck": true
   }
 }

--- a/packages/typescript-config/package.json
+++ b/packages/typescript-config/package.json
@@ -31,7 +31,8 @@
     "./react": "./react.json",
     "./next": "./next.json",
     "./tanstack-start": "./tanstack-start.json",
-    "./vite": "./vite.json"
+    "./vite": "./vite.json",
+    "./cloudflare-workers": "./cloudflare-workers.json"
   },
   "files": [
     "*.json",


### PR DESCRIPTION
## Summary
- Add `cloudflare-workers.json` TypeScript preset aligned with [Cloudflare's official TypeScript template](https://developers.cloudflare.com/workers/languages/typescript/)
- Add `cloudflareWorkers` ESLint config using `globals.serviceworker` and `globals.worker`
- Update READMEs and package exports

## Usage

**tsconfig.json:**
```json
{
  "extends": "@tractorbeam/typescript-config/cloudflare-workers.json"
}
```

For full type support, run `wrangler types` and include the generated file:
```json
{
  "extends": "@tractorbeam/typescript-config/cloudflare-workers.json",
  "include": ["worker-configuration.d.ts", "src/**/*.ts"]
}
```

**eslint.config.ts:**
```typescript
import { base, cloudflareWorkers, typescript } from "@tractorbeam/eslint-config";

export default defineConfig([base, typescript, cloudflareWorkers]);
```
