### PR TITLE
feat(typescript-config): inline @tsconfig/bases configs

### DIFF
--- a/.changeset/tricky-comics-laugh.md
+++ b/.changeset/tricky-comics-laugh.md
@@ -1,0 +1,5 @@
+---
+"@tractorbeam/typescript-config": minor
+---
+
+Inline @tsconfig/bases configs to fix extends resolution issues in consuming packages

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,11 +11,13 @@ This monorepo uses [Changesets](https://github.com/changesets/changesets) for ve
 The `changeset add` CLI requires an interactive TTY. To create changesets non-interactively (e.g., in Claude Code or CI):
 
 1. Create an empty changeset:
+
    ```bash
    pnpm changeset add --empty
    ```
 
 2. Edit the created file in `.changeset/` (it will have a random name like `funny-dogs-dance.md`):
+
    ```markdown
    ---
    "@tractorbeam/eslint-config": minor
@@ -25,6 +27,7 @@ The `changeset add` CLI requires an interactive TTY. To create changesets non-in
    ```
 
 **Bump types:**
+
 - `major` - Breaking changes
 - `minor` - New features (backwards compatible)
 - `patch` - Bug fixes

--- a/packages/eslint-config/CLAUDE.md
+++ b/packages/eslint-config/CLAUDE.md
@@ -8,8 +8,11 @@ The `@types/eslint` types don't recognize typescript-eslint nodes. Always import
 
 ```typescript
 // ✅ Correct
-import { AST_NODE_TYPES, ESLintUtils, TSESTree } from "@typescript-eslint/utils";
-
+import {
+  AST_NODE_TYPES,
+  ESLintUtils,
+  TSESTree,
+} from "@typescript-eslint/utils";
 // ❌ Avoid - types don't support TS nodes properly
 import type { Rule } from "eslint";
 ```
@@ -20,9 +23,13 @@ import type { Rule } from "eslint";
 const createRule = ESLintUtils.RuleCreator.withoutDocs;
 
 export const myRule = createRule({
-  meta: { /* ... */ },
-  defaultOptions: [],  // Required even if empty
-  create(context) { /* ... */ },
+  meta: {
+    /* ... */
+  },
+  defaultOptions: [], // Required even if empty
+  create(context) {
+    /* ... */
+  },
 });
 ```
 
@@ -125,6 +132,7 @@ const MAX_HEIGHT_PATTERN = /\bmax-h-(?!full\b|none\b)(\d+|\[.+?\]|\d+\/\d+)/;
 ```
 
 Pattern components:
+
 - `\b` - word boundary
 - `(?!full\b)` - negative lookahead, exclude "full"
 - `\d+` - numeric values (h-10)

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -85,6 +85,7 @@
   "dependencies": {
     "@eslint/js": "^9.39.2",
     "@tanstack/eslint-plugin-router": "^1.141.0",
+    "@typescript-eslint/utils": "^8.50.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-depend": "^1.4.0",
     "eslint-plugin-import-lite": "^0.4.0",
@@ -97,7 +98,6 @@
     "eslint-plugin-regexp": "^2.10.0",
     "eslint-plugin-unicorn": "^62.0.0",
     "eslint-plugin-zod": "^3.0.2",
-    "@typescript-eslint/utils": "^8.50.0",
     "globals": "^16.5.0",
     "typescript-eslint": "^8.50.0"
   },

--- a/packages/eslint-config/src/ui/rules/no-button-height-class.ts
+++ b/packages/eslint-config/src/ui/rules/no-button-height-class.ts
@@ -29,7 +29,9 @@ const WIDTH_PATTERN = new RegExp(`\\bw-(?!full\\b)${VALUE_PATTERN}`);
 const SIZE_PATTERN = new RegExp(`\\bsize-(?!full\\b)${VALUE_PATTERN}`);
 
 // min-h-* classes (except min-h-full, min-h-0)
-const MIN_HEIGHT_PATTERN = new RegExp(`\\bmin-h-(?!full\\b|0\\b)${VALUE_PATTERN}`);
+const MIN_HEIGHT_PATTERN = new RegExp(
+  `\\bmin-h-(?!full\\b|0\\b)${VALUE_PATTERN}`,
+);
 
 // max-h-* classes (except max-h-full, max-h-none)
 const MAX_HEIGHT_PATTERN = new RegExp(
@@ -37,7 +39,9 @@ const MAX_HEIGHT_PATTERN = new RegExp(
 );
 
 // min-w-* classes (except min-w-full, min-w-0)
-const MIN_WIDTH_PATTERN = new RegExp(`\\bmin-w-(?!full\\b|0\\b)${VALUE_PATTERN}`);
+const MIN_WIDTH_PATTERN = new RegExp(
+  `\\bmin-w-(?!full\\b|0\\b)${VALUE_PATTERN}`,
+);
 
 // max-w-* classes (except max-w-full, max-w-none)
 const MAX_WIDTH_PATTERN = new RegExp(
@@ -58,8 +62,7 @@ export const noButtonHeightClass = createRule({
   meta: {
     type: "suggestion",
     docs: {
-      description:
-        "Prefer size prop over sizing classes on Button components",
+      description: "Prefer size prop over sizing classes on Button components",
     },
     messages: {
       preferSizeProp:

--- a/packages/typescript-config/next.json
+++ b/packages/typescript-config/next.json
@@ -1,4 +1,20 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "extends": "@tsconfig/bases/next"
+  "compilerOptions": {
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
 }

--- a/packages/typescript-config/node.json
+++ b/packages/typescript-config/node.json
@@ -1,7 +1,13 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
-    "lib": ["es2024", "ESNext.Array", "ESNext.Collection", "ESNext.Iterator", "ESNext.Promise"],
+    "lib": [
+      "es2024",
+      "ESNext.Array",
+      "ESNext.Collection",
+      "ESNext.Iterator",
+      "ESNext.Promise"
+    ],
     "module": "nodenext",
     "target": "es2024",
     "strict": true,

--- a/packages/typescript-config/node.json
+++ b/packages/typescript-config/node.json
@@ -1,4 +1,12 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "extends": "@tsconfig/bases/node-lts"
+  "compilerOptions": {
+    "lib": ["es2024", "ESNext.Array", "ESNext.Collection", "ESNext.Iterator", "ESNext.Promise"],
+    "module": "nodenext",
+    "target": "es2024",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "moduleResolution": "nodenext"
+  }
 }

--- a/packages/typescript-config/node22.json
+++ b/packages/typescript-config/node22.json
@@ -1,4 +1,12 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "extends": "@tsconfig/bases/node22"
+  "compilerOptions": {
+    "lib": ["es2024", "ESNext.Array", "ESNext.Collection", "ESNext.Iterator"],
+    "module": "nodenext",
+    "target": "es2022",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "moduleResolution": "nodenext"
+  }
 }

--- a/packages/typescript-config/package.json
+++ b/packages/typescript-config/package.json
@@ -39,9 +39,6 @@
     "package.json",
     "README.md"
   ],
-  "dependencies": {
-    "@tsconfig/bases": "^1.0.16"
-  },
   "publishConfig": {
     "access": "public",
     "provenance": true

--- a/packages/typescript-config/react.json
+++ b/packages/typescript-config/react.json
@@ -1,4 +1,23 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "extends": "@tsconfig/bases/vite-react"
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  }
 }

--- a/packages/typescript-config/strictest.json
+++ b/packages/typescript-config/strictest.json
@@ -1,4 +1,19 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "extends": "@tsconfig/bases/strictest"
+  "compilerOptions": {
+    "strict": true,
+    "allowUnusedLabels": false,
+    "allowUnreachableCode": false,
+    "exactOptionalPropertyTypes": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,11 +115,7 @@ importers:
         specifier: ^0.7.2
         version: 0.7.2(@ianvs/prettier-plugin-sort-imports@4.7.0(prettier@3.7.4))(prettier@3.7.4)
 
-  packages/typescript-config:
-    dependencies:
-      '@tsconfig/bases':
-        specifier: ^1.0.16
-        version: 1.0.16
+  packages/typescript-config: {}
 
 packages:
 
@@ -411,9 +407,6 @@ packages:
     resolution: {integrity: sha512-E5QSLvoS8By2UajtUE64CNp22LVyzdqNyR/ponVV+yxONWHC3IzDUUHKBnPxW1yVwRT88qQoJYV0RJL6noW25A==}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
-
-  '@tsconfig/bases@1.0.16':
-    resolution: {integrity: sha512-BcuvYcRrWHm8/ZxFmUYQyIp74a7kEiNCw+e557bGnNUbqzzi/sw4BfwT8zbA9RPnDy4yPXSf3krJNjW8uRB4zA==}
 
   '@types/eslint-plugin-jsx-a11y@6.10.1':
     resolution: {integrity: sha512-5RtuPVe0xz8BAhrkn2oww6Uw885atf962Q4fqZo48QdO3EQA7oCEDSXa6optgJ1ZMds3HD9ITK5bfm4AWuoXFQ==}
@@ -2330,8 +2323,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - typescript
-
-  '@tsconfig/bases@1.0.16': {}
 
   '@types/eslint-plugin-jsx-a11y@6.10.1(jiti@2.6.1)':
     dependencies:


### PR DESCRIPTION
## Summary
- Inline all `@tsconfig/bases` configs to fix extends resolution issues in consuming packages
- Remove the `@tsconfig/bases` dependency entirely
- Update `moduleResolution` from deprecated `node16` to `nodenext` for Node configs

## Changes
- `node.json` - Inlined `@tsconfig/bases/node-lts` with modern `moduleResolution: "nodenext"`
- `node22.json` - Inlined `@tsconfig/bases/node22` with modern `moduleResolution: "nodenext"`
- `strictest.json` - Inlined `@tsconfig/bases/strictest`
- `react.json` - Inlined `@tsconfig/bases/vite-react`
- `next.json` - Inlined `@tsconfig/bases/next`
- `package.json` - Removed `@tsconfig/bases` dependency

## Context
When consuming packages extend configs from `@tractorbeam/typescript-config`, TypeScript resolves nested `extends` from the consumer's location rather than from the config package's location. This causes resolution failures for the `@tsconfig/bases/*` dependencies. Inlining the configs eliminates this issue.

## Changeset
Included - minor version bump for `@tractorbeam/typescript-config`