### PR TITLE
feat(typescript-config): add presets map export

### DIFF
--- a/.changeset/presets-export.md
+++ b/.changeset/presets-export.md
@@ -1,0 +1,5 @@
+---
+"@tractorbeam/typescript-config": minor
+---
+
+Add `./presets` export with a map of all preset configs for programmatic access.

--- a/packages/typescript-config/package.json
+++ b/packages/typescript-config/package.json
@@ -32,10 +32,12 @@
     "./next": "./next.json",
     "./tanstack-start": "./tanstack-start.json",
     "./vite": "./vite.json",
-    "./cloudflare-workers": "./cloudflare-workers.json"
+    "./cloudflare-workers": "./cloudflare-workers.json",
+    "./presets": "./presets.ts"
   },
   "files": [
     "*.json",
+    "*.ts",
     "package.json",
     "README.md"
   ],

--- a/packages/typescript-config/presets.ts
+++ b/packages/typescript-config/presets.ts
@@ -1,0 +1,19 @@
+import cloudflareWorkers from "./cloudflare-workers.json" with { type: "json" };
+import next from "./next.json" with { type: "json" };
+import node from "./node.json" with { type: "json" };
+import node22 from "./node22.json" with { type: "json" };
+import react from "./react.json" with { type: "json" };
+import strictest from "./strictest.json" with { type: "json" };
+import tanstackStart from "./tanstack-start.json" with { type: "json" };
+import vite from "./vite.json" with { type: "json" };
+
+export const presets: Record<string, Record<string, unknown>> = {
+  "cloudflare-workers": cloudflareWorkers,
+  next,
+  node,
+  node22,
+  react,
+  strictest,
+  "tanstack-start": tanstackStart,
+  vite,
+};


### PR DESCRIPTION
## Summary

- Adds a new `./presets` export to `@tractorbeam/typescript-config` that re-exports all preset JSON files as a single typed map
- This enables downstream tools (e.g. patrol) to import all presets with a single import rather than listing each preset individually

## Changes

- **`packages/typescript-config/presets.ts`** — New file that imports all preset JSON configs and exports them as a `Record<string, Record<string, unknown>>` map
- **`packages/typescript-config/package.json`** — Added `"./presets": "./presets.ts"` to exports and `"*.ts"` to the files array

## Test plan

- [ ] Verify `pnpm publish --dry-run` includes `presets.ts` in the package
- [ ] Verify downstream consumers can `import { presets } from "@tractorbeam/typescript-config/presets"`